### PR TITLE
Add dependency in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.ongres.scram</groupId>
+            <artifactId>client</artifactId>
+            <version>2.1</version>
+        </dependency>
+        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-service-discovery</artifactId>
         </dependency>


### PR DESCRIPTION
Added the following dependency in pom.xml to avoid `java.lang.ClassNotFoundException: com.ongres.scram.common.stringprep.StringPreparation` 
```
        <dependency>
            <groupId>com.ongres.scram</groupId>
            <artifactId>client</artifactId>
            <version>2.1</version>
        </dependency>
```