### PR TITLE
Make `itemType` uppercase in /verify JSON request

### DIFF
--- a/src/main/java/iudx/apd/acl/server/policy/VerifyPolicy.java
+++ b/src/main/java/iudx/apd/acl/server/policy/VerifyPolicy.java
@@ -38,7 +38,7 @@ public class VerifyPolicy {
     UUID ownerId = UUID.fromString(request.getJsonObject("owner").getString("id"));
     String userEmail = request.getJsonObject("user").getString("email");
     UUID itemId = UUID.fromString(request.getJsonObject("item").getString("itemId"));
-    ItemType itemType = ItemType.valueOf(request.getJsonObject("item").getString("itemType"));
+    ItemType itemType = ItemType.valueOf(request.getJsonObject("item").getString("itemType").toUpperCase());
     Future<JsonObject> checkForExistingPolicy =
         checkExistingPoliciesForId(itemId, ownerId, userEmail);
 


### PR DESCRIPTION
- The APD /verify auth request sends item type in the key `itemType` with possible values - `resource` and `resource_group` - both in lowercase by default
- Runtime error may have happened when manual testing since `ItemType.valueOf()` would have failed
- Making `itemType` uppercase will allow `ItemType.valueOf()` to work - no other changes should be required