### PR TITLE
Remove maxLength for email

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1947,7 +1947,6 @@ components:
           pattern: >-
             ^([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5})$
           minLength: 1
-          maxLength: 36
       required:
         - id
         - name
@@ -1967,7 +1966,6 @@ components:
           pattern: >-
             ^([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5})$
           minLength: 1
-          maxLength: 36
     item:
       type: object
       properties:


### PR DESCRIPTION
Removed the maxLength of email in verify policy to avoid validation exceptions from OpenAPI specs